### PR TITLE
URI Errors examples should mirror the tooltips

### DIFF
--- a/index.html
+++ b/index.html
@@ -285,12 +285,12 @@
                                 <label id="sidebarConceptCreatorInputLabel" for="sidebarConceptCreator" title="" skosFramework="Creator:" class="viewMode editMode absentForCompetencies frameworkOnly" skosFrameworkTitle="An entity primarily responsible for making the resource. For example, https://credentialengineregistry.org/, https://eduworks.com, https://case.georgiastandards.org/. Separate each entity with a comma." style="margin:0px;">Creator:</label>
                                 <p id="sidebarConceptCreator" class="viewMode editMode absentForCompetencies frameworkOnly" style="font-weight:bold;"></p>
                                 <input id="sidebarConceptCreatorInput" type="url" skosFramework="dcterms:creator" plural="true" class="editMode editControl absentForCompetencies frameworkOnly" />
-                                <span class="orangeUri">Note: URI only. Example, http://example.com/?t=idforFrameworkOwningorg</span>
+                                <span class="orangeUri">Note: URI only. For example, https://credentialengineregistry.org/, https://eduworks.com, https://case.georgiastandards.org/. Separate each entity with a comma.</span>
                                 <!-- Concept Scheme Publisher -->
                                 <label id="sidebarConceptPublisherInputLabel" for="sidebarConceptPublisher" title="" skosFramework="Publisher:" skosFrameworkTitle="A URI to an entity responsible for making this scheme available. For example, https://credentialengineregistry.org/, https://eduworks.com, https://case.georgiastandards.org/. Separate each entity with a comma." class="viewMode editMode absentForCompetencies frameworkOnly" style="margin:0px;">Publisher:</label>
                                 <p id="sidebarConceptPublisher" class="viewMode absentForCompetencies frameworkOnly" style="font-weight:bold;"></p>
                                 <input id="sidebarConceptPublisherInput" skosFramework="dcterms:publisher" plural="true" type="url" class="editMode editControl absentForCompetencies frameworkOnly" />
-                                <span class="orangeUri">Note: URI only. Example, http://example.com/?t=idforFrameworkPublishingorg</span>
+                                <span class="orangeUri">Note: URI only. For example, https://credentialengineregistry.org/, https://eduworks.com, https://case.georgiastandards.org/. Separate each entity with a comma.</span>
                                 <!-- Concept Scheme Publisher Name -->
                                 <label id="sidebarConceptPublisherNameInputLabel" for="sidebarConceptPublisherName" title="" skosFramework="Publisher Name:" skosFrameworkTitle="Name of the agent responsible for making this entity available. Separate each name with a comma." class="viewMode editMode absentForCompetencies frameworkOnly" style="margin:0px;">Publisher Name:</label>
                                 <p id="sidebarConceptPublisherName" class="viewMode absentForCompetencies frameworkOnly sidebarViewList" style="font-weight:bold;"></p>
@@ -371,12 +371,12 @@
                                             <label id="sidebarDerivedFromInputLabel" for="sidebarDerivedFrom" title="" cassCompetency="Derived From:" ceasnCompetency="Derivative Of:" class="viewMode editMode" style="margin:0px;">Derived From:</label>
                                             <p id="sidebarDerivedFrom" class="viewMode" style="font-weight:bold;"></p>
                                             <input id="sidebarDerivedFromInput" cassCompetency="ceasn:derivedFrom" ceasnCompetency="ceasn:derivedFrom" type="url" plural="true" class="editMode editControl" />
-                                            <span class="orangeUri">Note: URI only. Example http://example.com/?t=derivedFrom</span>
+                                            <span class="orangeUri">Note: URI only. For example, https://credentialengineregistry.org/, https://eduworks.com, https://case.georgiastandards.org/. Separate each entity with a comma.</span>
                                             <!-- Identifier -->
                                             <label id="sidebarIdentifierInputLabel" for="sidebarIdentifier" title="" cassCompetency="Identifier:" ceasnCompetency="Identifier:" skosCompetency="Identifier:" plural="true" class="viewMode editMode" style="margin:0px;">Identifier:</label>
                                             <p id="sidebarIdentifier" class="viewMode" style="font-weight:bold;"></p>
                                             <input cassCompetency="schema:identifier" ceasnCompetency="ceasn:identifier" id="sidebarIdentifierInput" type="url" class="editMode editControl" />
-                                            <span class="orangeUri">Note: URI only. Example, https://sandbox.credentialengineregistry.org/</span>
+                                            <span class="orangeUri">Note: URI only. For example, https://sandbox.credentialengineregistry.org/. Separate each URI with a comma.</span>
                                             <!-- List ID -->
                                             <label id="sidebarListIdInputLabel" for="sidebarListId" title="" cassCompetency="List ID:" ceasnCompetency="List ID:" class="viewMode editMode" style="margin:0px;">List ID:</label>
                                             <p id="sidebarListId" class="viewMode" style="font-weight:bold;"></p>
@@ -419,7 +419,7 @@
                                         <label id="sidebarCreatorInputLabel" for="sidebarCreator" title="" cassFramework="Creator:" ceasnFramework="Creator:" class="viewMode editMode absentForConcepts" style="margin:0px;">Creator:</label>
                                         <p id="sidebarCreator" class="viewMode absentForConcepts" style="font-weight:bold;"></p>
                                         <input id="sidebarCreatorInput" cassFramework="schema:creator" ceasnFramework="ceasn:creator" plural="true" type="url" class="editMode editControl absentForConcepts" />
-                                        <span class="orangeUri">Note: URI only. Example, http://example.com/?t=idforFrameworkOwningorg</span>
+                                        <span class="orangeUri">Note: URI only. For example: https://credentialengineregistry.org/, https://eduworks.com, https://case.georgiastandards.org/. Separate each entity with a comma.</span>
                                         <!-- Publisher Name -->
                                         <label id="sidebarPublisherNameInputLabel" for="sidebarPublisherName" title="" cassFramework="Publisher Name:" ceasnFramework="Publisher Name:" class="viewMode editMode absentForConcepts" style="margin:0px;">Publisher Name:</label>
                                         <p id="sidebarPublisherName" class="viewMode absentForConcepts sidebarViewList" style="font-weight:bold;"></p>
@@ -433,7 +433,7 @@
                                         <label id="sidebarPublisherInputLabel" for="sidebarPublisher" title="" cassFramework="Publisher:" ceasnFramework="Publisher:" class="viewMode editMode absentForConcepts" style="margin:0px;">Publisher:</label>
                                         <p id="sidebarPublisher" class="viewMode absentForConcepts" style="font-weight:bold;"></p>
                                         <input id="sidebarPublisherInput" cassFramework="schema:publisher" ceasnFramework="ceasn:publisher" plural="true" type="url" class="editMode editControl absentForConcepts" />
-                                        <span class="orangeUri">Note: URI only. Example, http://example.com/?t=idforFrameworkPublishingorg</span>
+                                        <span class="orangeUri">Note: URI only. For example: https://credentialengineregistry.org/, https://eduworks.com, https://case.georgiastandards.org/. Separate each entity with a comma.</span>
                                         <!-- In Language -->
                                         <label id="sidebarInLanguageInputLabel" for="sidebarInLanguage" title="" cassFramework="In Language:" ceasnFramework="In Language:" class="viewMode editMode absentForConcepts" style="margin:0px;">In Language:</label>
                                         <p id="sidebarInLanguage" class="viewMode absentForConcepts" style="font-weight:bold;"></p>
@@ -459,17 +459,17 @@
                                             <label id="sidebarDerivedFromInputLabel" for="sidebarDerivedFrom" title="" cassFramework="Derived From:" ceasnFramework="Derived From:" class="viewMode editMode" style="margin:0px;">Derived From:</label>
                                             <p id="sidebarDerivedFrom" class="viewMode" style="font-weight:bold;"></p>
                                             <input id="sidebarDerivedFromInput" cassFramework="ceasn:derivedFrom" ceasnFramework="ceasn:derivedFrom" type="url" plural="true" class="editMode editControl" />
-                                            <span class="orangeUri">Note: URI only. Example, http://example.com/?t=derivedFrom</span>
+                                            <span class="orangeUri">Note: URI only. For example: https://credentialengineregistry.org/, https://eduworks.com, https://case.georgiastandards.org/. Separate each entity with a comma.</span>
                                             <!-- Is Version Of -->
                                             <label id="sidebarIsVersionOfInputLabel" for="sidebarIsVersionOf" title="" cassFramework="Version Of:" ceasnFramework="Is Version Of:" class="viewMode editMode" style="margin:0px;">Version Of:</label>
                                             <p id="sidebarVersionOf" class="viewMode" style="font-weight:bold;"></p>
                                             <input id="sidebarVersionOfInput" cassFramework="isVersionOf" ceasnFramework="isVersionOf" type="url" class="editMode editControl" />
-                                            <span class="orangeUri">Note: URI only. Example, http://example.com/?t=isVersionOf</span>
+                                            <span class="orangeUri">Note: URI only. For example: https://credentialengineregistry.org/</span>
                                             <!-- Framework Source -->
                                             <label id="sidebarSourceInputLabel" for="sidebarSource" title="" cassFramework="Source:" ceasnFramework="Source Framework:" class="viewMode editMode" style="margin:0px;">Source:</label>
                                             <p id="sidebarSource" class="viewMode" style="font-weight:bold;"></p>
                                             <input id="sidebarSourceInput" cassFramework="dc:source" ceasnFramework="ceasn:source" type="url" plural="true" class="editMode editControl" />
-                                            <span class="orangeUri">Note: URI only. Example, http://example.com/?t=source</span>
+                                            <span class="orangeUri">Note: URI only. For example: https://credentialengineregistry.org/, https://eduworks.com, https://case.georgiastandards.org/. Separate each original framework with a comma.</span>
                                         </div>
                                         <!-- Framework Context Section -->
                                         <h2 class="editMode" style="margin-bottom:0px;cursor:pointer;" onclick="toggleDiv('frameworkContextChevron', 'frameworkContext');">Context <i class="fa fa-chevron-down" id="frameworkContextChevron" style="float:right;"></i></h2>
@@ -495,7 +495,7 @@
                                             <label id="sidebarHistoryNoteInputLabel" for="sidebarHistoryNote" title="" cassFramework="History Note:" skosFramework="History Note:" class="viewMode editMode" style="margin:0px;">History Note:</label>
                                             <p id="sidebarHistoryNote" class="viewMode" style="font-weight:bold;"></p>
                                             <input id="sidebarHistoryNoteInput" cassFramework="skos:historyNote" skosFramework="skos:historyNote" plural="true" type="url" class="editMode editControl" />
-                                            <span class="orangeUri">Note: URI only. Example, http://example.com/?t=idforHistoryNote</span>
+                                            <span class="orangeUri">Note: URI only. For example, https://credentialengineregistry.org/.</span>
                                             <!-- Publication Status -->
                                             <label for="sidebarPublicationStatus" title="" cassFramework="Publication Status:" ceasnFramework="Source Publication Status:" skosFramework="Publication Status:" class="viewMode editMode" style="margin:0px;">Publication Status:</label>
                                             <p id="sidebarPublicationStatus" class="viewMode" style="font-weight:bold;"></p>
@@ -509,7 +509,7 @@
                                             <label id="sidebarIdentifierInputLabel" for="sidebarIdentifier" title="" cassFramework="Identifier:" ceasnFramework="Identifier:" class="viewMode editMode absentForConcepts" style="margin:0px;">Identifier:</label>
                                             <p id="sidebarIdentifier" class="viewMode absentForConcepts" style="font-weight:bold;"></p>
                                             <input cassFramework="schema:identifier" ceasnFramework="ceasn:identifier" plural="true" id="sidebarIdentifierInput" type="url" class="editMode editControl absentForConcepts" />
-                                            <span class="orangeUri">Note: URI only. Example, https://sandbox.credentialengineregistry.org/</span>
+                                            <span class="orangeUri">Note: URI only. For example, https://sandbox.credentialengineregistry.org/. Separate each URI with a comma.</span>
                                         </div>
                                         <!-- Framework Rights Section -->
                                         <h2 class="editMode" style="margin-bottom:0px;cursor:pointer;" onclick="toggleDiv('frameworkRightsChevron', 'frameworkRights');">Rights <i class="fa fa-chevron-down" id="frameworkRightsChevron" style="float:right;"></i></h2>
@@ -523,17 +523,17 @@
                                             <label id="sidebarLicenseInputLabel" for="sidebarLicense" title="" cassFramework="License:" ceasnFramework="License:" skosFramework="License:" class="viewMode editMode" style="margin:0px;">License:</label>
                                             <p id="sidebarLicense" class="viewMode" style="font-weight:bold;"></p>
                                             <input id="sidebarLicenseInput" cassFramework="schema:license" ceasnFramework="ceasn:license" skosFramework="dcterms:license" type="url" class="editMode editControl" />
-                                            <span class="orangeUri">Note: URI only. Example, https://sandbox.credentialengineregistry.org/</span>
+                                            <span class="orangeUri">Note: URI only. For example, https://sandbox.credentialengineregistry.org/</span>
                                             <!-- Rights -->
                                             <label id="sidebarRightsInputLabel" for="sidebarRights" title="" cassFramework="Rights:" ceasnFramework="Rights:" skosFramework="Rights:" class="viewMode editMode" style="margin:0px;">Rights:</label>
                                             <p id="sidebarRights" class="viewMode" style="font-weight:bold;"></p>
                                             <input id="sidebarRightsInput" cassFramework="dc:rights" ceasnFramework="ceasn:rights" skosFramework="dcterms:rights" type="url" class="editMode editControl" />
-                                            <span class="orangeUri">Note: URI only. Example, http://example.com/?t=idforRights</span>
+                                            <span class="orangeUri">Note: URI only. For example, https://sandbox.credentialengineregistry.org/</span>
                                             <!-- Rights Holder -->
                                             <label id="sidebarRightsHolderInputLabel" for="sidebarRightsHolder" title="" cassFramework="Rights Holder:" ceasnFramework="Rights Holder:" skosFramework="Rights Holder:" class="viewMode editMode" style="margin:0px;">Rights Holder:</label>
                                             <p id="sidebarRightsHolder" class="viewMode" style="font-weight:bold;"></p>
                                             <input id="sidebarRightsHolderInput" cassFramework="schema:copyrightHolder" ceasnFramework="ceasn:rightsHolder" skosFramework="dcterms:rightsHolder" type="url" class="editMode editControl" />
-                                            <span class="orangeUri">Note: URI only. Example, http://example.com/?t=idforRights</span>
+                                            <span class="orangeUri">Note: URI only. For example, https://credentialengineregistry.org/</span>
                                         </div>
                                     </div>
                                 </div>

--- a/js/util.js
+++ b/js/util.js
@@ -565,7 +565,7 @@ initTooltips = function (type) {
             hide: false
         });
         $('label[for="sidebarDerivedFrom"]').tooltip({
-            content: 'The URI of a competency from which this competency has been derived. For example: https://credentialengineregistry.org/, https://eduworks.com, https://case.georgiastandards.org/.  Separate each entity with a comma.',
+            content: 'The URI of a competency from which this competency has been derived. For example: https://credentialengineregistry.org/, https://eduworks.com, https://case.georgiastandards.org/. Separate each entity with a comma.',
             show: false,
             hide: false
         });


### PR DESCRIPTION
Change input text URI error messages to be similar to display URIs in tooltips. Fix issue #334.