### PR TITLE
Concept deleted remains in concept scheme

### DIFF
--- a/js/editConcept.js
+++ b/js/editConcept.js
@@ -5,6 +5,7 @@ addConcept = function () {
         initIframe();
         showPage("#findCompetencySection", framework);
     } else if (addOrSearch == "new") {
+        isFirstEdit = true;
         previousSelectedCompetency = selectedCompetency;
         var c = new EcConcept();
         if (newObjectEndpoint != null)


### PR DESCRIPTION
Add boolean variable to track if first edit or not in add concept so when cancel edit will prompt for confirmation and delete unsaved concept within scheme. Fix issue #164 Concept: deleted a concept but still appears in list on the left 