### PR TITLE
#163 Adding competency via autocomplete sidebar fix

### DIFF
--- a/js/viewFramework.js
+++ b/js/viewFramework.js
@@ -1045,6 +1045,7 @@ editSidebar = function () {
                         repo.saveTo(framework, function () {
                             appendCompetencies(results, true);
                         }, error);
+                        selectedCompetency = competency;
                     }
                 }
             });


### PR DESCRIPTION
When adding a competency by selecting an autocomplete option, the sidebar now shows the correct competency. Previously showed "New Competency" on the sidebar. Part of issue #163.