### PR TITLE
Concept Drag and Drop issue fix

### DIFF
--- a/js/editConcept.js
+++ b/js/editConcept.js
@@ -245,6 +245,9 @@ dropAnyConcept = function (data, targetData) {
         delete thing["skos:topConceptOf"];
         EcArray.setRemove(framework["skos:hasTopConcept"], thing.shortId());
     }
+    // replaced selected concept with changed concept
+    selectedCompetency = thing;
+    refreshSidebar();
     repo.saveTo(thing, function () {
         repo.saveTo(targetThing, afterSave, console.error);
     }, console.error);

--- a/js/viewConceptScheme.js
+++ b/js/viewConceptScheme.js
@@ -40,7 +40,9 @@ function afterConceptRefresh(level, subsearch) {
 
 function refreshConcept(col, level, subsearch, recurse) {
     var me = this;
-    me.fetches--;
+    if (me.fetches > 0) {
+        me.fetches--;
+    }
     if (recurse == null) recurse = [];
     if (EcArray.has(recurse, col.shortId())) {
         if (me.fetches == 0) {


### PR DESCRIPTION
After concept is dropped, replace selected concept with changed concept and render sidebar to update concept connections. Check counter in refresh concept function before decrement. Fix for testing issue found in issue #348.