### PR TITLE
Collapse Competency Hierarchy

### DIFF
--- a/js/editConcept.js
+++ b/js/editConcept.js
@@ -17,6 +17,7 @@ addConcept = function () {
         c["skos:prefLabel"] = "New Concept";
         c["skos:inScheme"] = framework.shortId();
         if (selectedCompetency != null) {
+            collapseCompetencyTracking(framework.shortId(),selectedCompetency.shortId(),"expanded");
             if (selectedCompetency["skos:narrower"] == null)
                 selectedCompetency["skos:narrower"] = [];
             EcArray.setAdd(selectedCompetency["skos:narrower"], c.shortId());

--- a/js/editFramework.js
+++ b/js/editFramework.js
@@ -36,6 +36,7 @@ addCompetency = function () {
         framework["schema:dateModified"] = new Date().toISOString();
         repo.saveTo(c, function () {
             if (selectedCompetency != null) {
+                collapseCompetencyTracking(framework.shortId(),selectedCompetency.shortId(),"expanded");
                 var r = new EcAlignment();
                 if (newObjectEndpoint != null)
                     r.generateShortId(newObjectEndpoint == null ? repo.selectedServer : newObjectEndpoint);


### PR DESCRIPTION
Fix issue where saving collapsed competencies in local storage was not using framework short identifier so upon any refresh no stored collapsed competencies in local storage matched. Fixes issue #390.