### PR TITLE
None field fix

### DIFF
--- a/css/cass-editor.css
+++ b/css/cass-editor.css
@@ -230,6 +230,10 @@ p.selected {
     overflow: hidden;
 }
 
+ul.ui-autocomplete {
+	display:none;
+}
+
 .ui-tooltip {
     border-radius: 5px;
     background-color: white;

--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -217,6 +217,10 @@ p.selected {
     overflow: hidden;
 }
 
+ul.ui-autocomplete {
+    display:none;
+}
+
 .ui-tooltip {
     border-radius: 5px;
     background-color: white;


### PR DESCRIPTION
This should prevent the "None" field from showing up, it does appear to be related to the Autocomplete widget. Issue #394 