### PR TITLE
Collapse Expand All Competencies in Framework

### DIFF
--- a/index.html
+++ b/index.html
@@ -817,6 +817,8 @@
 			<span id="frameworkCreated"></span>
 			<span id="frameworkLastModified"></span>
 			<span id="frameworkCount"></span>
+			<button id="collapseAllCompetencies" class="viewMode absentForConcepts" style="float:right;font-size:22px;color:black;display: none;" onclick="collapseAllCompetencies()" title="Collapse All."><i class="fa fa-minus-square"  aria-hidden='true'></i></button>
+			<button id="expandAllCompetencies" class="viewMode absentForConcepts" style="float:right;font-size:22px;color:black;display: none;" onclick="expandAllCompetencies()" title="Expand All."><i class="fa fa-plus-square"  aria-hidden='true'></i></button>
 			<div id="frameworkAKA"></div>
 			<hr style="margin-bottom: -1px;">
 		</div>

--- a/js/viewFramework.js
+++ b/js/viewFramework.js
@@ -154,6 +154,11 @@ populateFramework = function (subsearch) {
 		if (queryParams.link == "true")
 			$("#editFrameworkSection #frameworkLink").attr("href", framework.shortId()).show();
 
+	if ($("#collapseAllCompetencies").css("display") != 'none') {
+		$("#collapseAllCompetencies").css("display", "none");
+		$("#expandAllCompetencies").css("display", "none");
+	}
+
 	if (framework.competency == null)
 		framework.competency = [];
 	if (framework.relation == null)
@@ -269,8 +274,13 @@ function refreshCompetency(col, level, subsearch) {
 		level = true;
 		$(".competency[id=\"" + col.competency + "\"]").children().last().append($(".competency[id=\"" + col.shortId() + "\"]"));
 		treeNode.children().first().append(" <small>(Performance Level)</small>");
-		if (!$(".competency[id=\"" + col.competency + "\"]").hasClass("expandable"))
+		if (!$(".competency[id=\"" + col.competency + "\"]").hasClass("expandable")) {
 			$(".competency[id=\"" + col.competency + "\"]").addClass("expandable").children(".collapse").css("visibility", "visible");
+			if ($("#collapseAllCompetencies").css("display") === 'none') {
+				$("#collapseAllCompetencies").css("display", "");
+				$("#expandAllCompetencies").css("display", "");
+			}
+		}
 	}
 	if (queryParams.link == "true")
 		treeNode.prepend(" <a class='link' title='Click to navigate to link address. Right click to copy link address.' style='float:right;' target='_blank'><i class='fa fa-link' aria-hidden='true'></a>").children().first().attr("href", col.shortId());
@@ -305,8 +315,14 @@ function refreshCompetency(col, level, subsearch) {
 											$("#tree>.competency[id=\"" + source.shortId() + "\"]").remove();
 										}
 									}
-									if ($(".competency[id=\"" + source.shortId() + "\"]").length && !$(".competency[id=\"" + target.shortId() + "\"]").hasClass("expandable"))
+									if ($(".competency[id=\"" + source.shortId() + "\"]").length &&
+										!$(".competency[id=\"" + target.shortId() + "\"]").hasClass("expandable")) {
 										$(".competency[id=\"" + target.shortId() + "\"]").addClass("expandable").children(".collapse").css("visibility", "visible");
+										if ($("#collapseAllCompetencies").css("display") === 'none') {
+											$("#collapseAllCompetencies").css("display", "");
+											$("#expandAllCompetencies").css("display", "");
+										}
+									}
 								}
 						}
 					}
@@ -1591,6 +1607,25 @@ collapseCompetencyTracking = function(fId, cId, toggleState) {
 	}
 }
 
+collapseAllCompetencies = function() {
+	if (conceptMode)
+		return;
+	if (framework.competency == null || framework.competency.length == 0)
+		return;
+	for (var i = 0; i < framework.competency.length; i++) {
+		var competencyId = framework.competency[i];
+		var competency = $("#tree [id='" + competencyId + "']");
+		if (competency.length > 0) {
+			if (competency.hasClass('expandable')){
+				collapseCompetencyTracking(framework.shortId(), competencyId, 'collapsed');
+			}//end if competency expandable
+		}//end if
+	}//end for each competency
+	selectedCompetency = null; // so sidebar display of competency is cleared
+	refreshSidebar();
+	collapseCompetencies();
+}
+
 collapseCompetencies = function () {
 	var collapseDict = JSON.parse(localStorage.getItem('collapseDict'));
 	var fId = framework.shortId();
@@ -1603,6 +1638,27 @@ collapseCompetencies = function () {
 				elem.children('ul').hide();
 			}
 		});
+}
+
+expandAllCompetencies = function() {
+	if (conceptMode)
+		return;
+	if (framework.competency == null || framework.competency.length == 0)
+		return;
+	for (var i = 0; i < framework.competency.length; i++) {
+		var competencyId = framework.competency[i];
+		var competency = $("#tree [id='" + competencyId + "']");
+		if (competency.length > 0) {
+			if (competency.hasClass('expandable')) {
+				if (competency.children('.collapse').hasClass('collapsed')){
+					competency.children("ul").slideToggle();
+					competency.children('.collapse').removeClass('collapsed');
+					competency.children('.collapse').children('i').removeClass('fa-plus-square').addClass('fa-minus-square');
+					collapseCompetencyTracking(framework.shortId(), competencyId, 'expanded');
+				}//end if competency collapsed
+			}//end if competency expandable
+		}//end if competency
+	}//end for each competencies
 }
 
 validateString = function (str) {

--- a/js/viewFramework.js
+++ b/js/viewFramework.js
@@ -1458,6 +1458,14 @@ $('html').keydown(function (evt) {
 		}
 		//If we're on the editFrameworks section
 		else if ($('#editFrameworkSection').css('display') === 'block') {
+			// asterisk key or Shift+8 = asterisk(*)
+			if (evt.which === 170 || (evt.shiftKey && evt.which === 56)) {
+				expandAllCompetencies();
+			}
+			// slash (forward)
+			else if (evt.which === 191) {
+				collapseAllCompetencies();
+			}
 			var competencyElementArray = $('#tree').find('.competency:visible');
 			if (competencySelectionIndex === null) {
 				competencySelectionIndex = -1;
@@ -1635,6 +1643,7 @@ collapseCompetencies = function () {
 				var elem = $('[id="' + key + '"]');
 				elem.children('.collapse').addClass('collapsed');
 				elem.children('.collapse').children('i').removeClass('fa-minus-square').addClass('fa-plus-square');
+				elem.children('ul').slideToggle();
 				elem.children('ul').hide();
 			}
 		});
@@ -1651,7 +1660,7 @@ expandAllCompetencies = function() {
 		if (competency.length > 0) {
 			if (competency.hasClass('expandable')) {
 				if (competency.children('.collapse').hasClass('collapsed')){
-					competency.children("ul").slideToggle();
+					competency.children('ul').slideToggle();
 					competency.children('.collapse').removeClass('collapsed');
 					competency.children('.collapse').children('i').removeClass('fa-plus-square').addClass('fa-minus-square');
 					collapseCompetencyTracking(framework.shortId(), competencyId, 'expanded');


### PR DESCRIPTION
Add 2 buttons to collapse or expand all competencies within a framework. Buttons will be displayed only if any competency within framework is expandable (or collapsible) . Keyboard shortcuts (forward) slash for collapse all and asterisk for expand all. Addresses issue #366.