### PR TITLE
Global Collapse Expand Buttons Fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -814,11 +814,15 @@
 			<br>
 			<!--            <span id="frameworkLastModified"></span>-->
 			<div id="frameworkDescription"></div>
-			<span id="frameworkCreated"></span>
-			<span id="frameworkLastModified"></span>
-			<span id="frameworkCount"></span>
-			<button id="collapseAllCompetencies" class="viewMode absentForConcepts" style="float:right;font-size:22px;color:black;display: none;" onclick="collapseAllCompetencies()" title="Collapse All."><i class="fa fa-minus-square"  aria-hidden='true'></i></button>
-			<button id="expandAllCompetencies" class="viewMode absentForConcepts" style="float:right;font-size:22px;color:black;display: none;" onclick="expandAllCompetencies()" title="Expand All."><i class="fa fa-plus-square"  aria-hidden='true'></i></button>
+			<div id="frameworkStats" style="overflow:auto">
+				<span id="frameworkCreated"></span>
+				<span id="frameworkLastModified"></span>
+				<span id="frameworkCount"></span>
+				<span id="collapseExpandAll" style="float:right;">
+					<button id="expandAllCompetencies" class="viewMode absentForConcepts" style="color:black;display:none;" onclick="expandAllCompetencies()" title="Expand All."><i class="fa fa-plus-square"  aria-hidden='true'></i></button>
+					<button id="collapseAllCompetencies" class="viewMode absentForConcepts" style="color:black;display:none;" onclick="collapseAllCompetencies()" title="Collapse All."><i class="fa fa-minus-square"  aria-hidden='true'></i></button>
+				</span>
+			</div>
 			<div id="frameworkAKA"></div>
 			<hr style="margin-bottom: -1px;">
 		</div>


### PR DESCRIPTION
Apply style changes to Collapse All and Expand All buttons. Also apply overflow to buttons so they stay together when window size changes. Fix for issue #366.