### PR TITLE
Notification displayed for longer when some objects fail to save with…

### DIFF
--- a/js/import.js
+++ b/js/import.js
@@ -185,11 +185,23 @@ function importCtdlAsnCsv() {
             });
         }, function (allDone) {
             Task.asyncImmediate(function (callback) {
-                showPage("framework");
-                populateFramework();
-                selectedCompetency = null;
-                refreshSidebar();
-                callback();
+                if (failed > 0) {
+                    loading(failed + " objects failed to save. Check your import file for any errors.");
+                    setTimeout(function () {
+                        showPage("framework");
+                        populateFramework();
+                        selectedCompetency = null;
+                        refreshSidebar();
+                        callback();
+                    }, 5000);
+                }
+                else {
+                    showPage("framework");
+                    populateFramework();
+                    selectedCompetency = null;
+                    refreshSidebar();
+                    callback();
+                }
             });
         });
     }, function (failure) {


### PR DESCRIPTION
After import is complete, the user will see the number of objects that failed to import for longer before displaying the framework. Per Eddie's suggestions on issue #161 