### PR TITLE
Relation file selection no longer carries over from one CSV import to the next

### DIFF
--- a/js/import.js
+++ b/js/import.js
@@ -23,6 +23,8 @@ function importFile() {
 
         }, function (errorMsg) {
             CSVImport.analyzeFile(file, function (data) {
+                $("#importCsvRelation").val(null);
+                $(".importCsvRelationOptions").hide();
                 $("#importCsvColumnName").html("<option>N/A</option>");
                 $("#importCsvColumnDescription").html("<option>N/A</option>");
                 $("#importCsvColumnScope").html("<option>N/A</option>");


### PR DESCRIPTION
Upon second import, there is now no relation file selected. Previously, the one used in the last import was still linked.