### PR TITLE
Retain number of frameworks selected

### DIFF
--- a/js/editFramework.js
+++ b/js/editFramework.js
@@ -448,7 +448,7 @@ deleteCompetency = function () {
         if (isFirstEdit) {
             spitEvent("frameworkDeleted", framework.shortId());
             if (defaultPage == "#frameworksSection")
-                searchFrameworks(createParamObj(20));
+                searchFrameworks(createParamObj());
             else
                 showPage(defaultPage);
         }
@@ -458,7 +458,7 @@ deleteCompetency = function () {
                     repo.deleteRegistered(framework, function (success) {
                         spitEvent("frameworkDeleted", framework.shortId());
                         if (defaultPage == "#frameworksSection")
-                            searchFrameworks(createParamObj(20));
+                            searchFrameworks(createParamObj());
                         else
                             showPage(defaultPage);
                         //Delete the framework, delete all non-used stuff.

--- a/js/util.js
+++ b/js/util.js
@@ -211,7 +211,7 @@ initTooltips = function (type) {
 
 resetSearch = function () {
 	$('#search').val('');
-	searchFrameworks(createParamObj(5000));
+	searchFrameworks(createParamObj(20));
 }
 
 highlightSelected = function (element) {

--- a/js/viewFrameworks.js
+++ b/js/viewFrameworks.js
@@ -2,11 +2,12 @@ if (queryParams.select != null)
     if (parent != window)
         $("#frameworksBack").show();
 
+var paramSize;
 function searchFrameworks(paramObj) {
     if (conceptMode)
         return searchConceptSchemes(paramObj);
     if (paramObj.size == null)
-        paramObj.size = 20;
+        paramObj.size = paramSize ? paramSize : 20;
     loading("Loading frameworks...");
     var searchTerm = $("#search").val();
     if (searchTerm == null || searchTerm == "") {
@@ -25,6 +26,7 @@ function searchFrameworks(paramObj) {
             frameworkSearchByCompetency(servers[i], searchTerm);
         }
     }
+    paramSize = paramObj.size;
 }
 var frameworkLoading = 0;
 
@@ -221,12 +223,12 @@ function checkForChangesBeforeBack(event) {
             event.stopPropagation();
             return;
         } else {
-            searchFrameworks(createParamObj(20));
+            searchFrameworks(createParamObj());
             framework = null;
             selectedCompetency = null;
         }
     } else {
-        searchFrameworks(createParamObj(20));
+        searchFrameworks(createParamObj());
         framework = null;
         selectedCompetency = null;
     }


### PR DESCRIPTION
Part of issue #237 

The search will now retain the number of frameworks previously selected. If the user starts a new search or exits out of the search, the number will go back to 20.