### PR TITLE
Allow cancel on import of JSON files

### DIFF
--- a/src/components/import/ImportFile.vue
+++ b/src/components/import/ImportFile.vue
@@ -411,6 +411,9 @@ export default {
         }
     },
     methods: {
+        cancelImport: function() {
+            this.$store.dispatch('app/clearImport');
+        },
         clearFiles: function() {
             this.$store.commit('app/clearImportFiles');
         },

--- a/src/mixins/import.js
+++ b/src/mixins/import.js
@@ -854,8 +854,10 @@ export default {
                 var identity = EcIdentityManager.default.ids[0];
                 if (identity != null) { formData.append('owner', identity.ppk.toPk().toPem()); }
                 let me = this;
+                me.$store.commit('app/importAllowCancel', true);
                 me.$store.commit('app/importFramework', null);
                 EcRemote.postInner(this.repo.selectedServer, "ctdlasn", formData, null, async function(data) {
+                    me.$store.commit('app/importAllowCancel', false);
                     var framework;
                     if (EcRepository.cache) {
                         delete EcRepository.cache[data];

--- a/src/store/modules/app.js
+++ b/src/store/modules/app.js
@@ -51,7 +51,6 @@ const state = {
         type: 'file', // pdf, server, text
         fileType: '',
         firstImport: Boolean,
-        allowCancel: false,
         errors: [], // erorrs from the code or from the api
         feedback: '', // additional information
         framework: null,
@@ -74,6 +73,7 @@ const state = {
         csvRelationFile: null,
         importModalParams: null
     },
+    allowCancel: false,
     banner: {
         message: '',
         color: '',
@@ -212,7 +212,7 @@ const mutations = {
         state.import.status = val;
     },
     importAllowCancel: function(state, val) {
-        state.import.allowCancel = val;
+        state.allowCancel = val;
     },
     importFeedback: function(state, val) {
         state.import.feedback = val;
@@ -439,7 +439,7 @@ const getters = {
         return state.import.status;
     },
     importAllowCancel: state => {
-        return state.import.allowCancel;
+        return state.allowCancel;
     },
     importFeedback: state => {
         return state.import.feedback;


### PR DESCRIPTION
Cancel is allowed only during import processing. Option to cancel is removed while saving to maintain data integrity.