### PR TITLE
Set axios withCredentials option if cors credentials are enabled

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -149,6 +149,9 @@ export default {
                         this.$store.commit('app/showModal', {component: 'MessageOfTheDay'});
                     }
                 }
+                if (loginInfo.corsCredentials) {
+                    global.axiosOptions.withCredentials = loginInfo.corsCredentials;
+                }
                 if (window.EcIdentityManager.default.ids.length > 0) {
                     try {
                         let pers = (await window.EcPerson.getByPk(r, window.EcIdentityManager.default.ids[0].ppk.toPk()));


### PR DESCRIPTION
Sets the axios withCredentials property to true if the CaSS server has set CORS_CREDENTIALS to true