### PR TITLE
Update DateModified type to date from dateTime

### DIFF
--- a/src/lode/components/PropertyString.vue
+++ b/src/lode/components/PropertyString.vue
@@ -376,14 +376,10 @@ export default {
                     if (this.range[0] === 'http://www.w3.org/2001/XMLSchema#dateTime' && this.text["@value"].length > 16) {
                         return this.text["@value"].substr(0, 16);
                     }
+                    if (this.range[0] === 'http://www.w3.org/2001/XMLSchema#date' && this.text["@value"].length > 10) {
+                        return this.text["@value"].substr(0, 10);
+                    }
                     return this.text["@value"];
-                }
-                if (this.range[0] === 'http://www.w3.org/2001/XMLSchema#dateTime' && this.text === "") {
-                    // CE requested that the default seconds are set to 12am when adding a new Date Modified because most customers will only add a date when setting
-                    //  a retroactive Date Modified value, even though the schema supports date and time.
-                    const today = new Date();
-                    const dateOut = `${today.getFullYear()}-${today.getMonth() + 1}-${today.getDate()}T00:00`;
-                    return dateOut;
                 }
                 return this.text;
             },

--- a/src/mixins/ctdlasnProfile.js
+++ b/src/mixins/ctdlasnProfile.js
@@ -270,7 +270,7 @@ export default {
                     "@type": ["http://www.w3.org/2000/01/rdf-schema#Property"],
                     "http://schema.org/domainIncludes":
                     [{"@id": "https://schema.cassproject.org/0.4/Framework"}],
-                    "http://schema.org/rangeIncludes": [{"@id": "http://www.w3.org/2001/XMLSchema#dateTime"}],
+                    "http://schema.org/rangeIncludes": [{"@id": "http://www.w3.org/2001/XMLSchema#date"}],
                     "http://www.w3.org/2000/01/rdf-schema#comment":
                     [{"@language": "en", "@value": "The date on which this resource was most recently modified in some way."}],
                     "http://www.w3.org/2000/01/rdf-schema#label": [{"@language": "en", "@value": "Date Modified"}],
@@ -804,7 +804,7 @@ export default {
                     "@type": ["http://www.w3.org/2000/01/rdf-schema#Property"],
                     "http://schema.org/domainIncludes":
                     [{"@id": "https://schema.cassproject.org/0.4/Competency"}],
-                    "http://schema.org/rangeIncludes": [{"@id": "http://www.w3.org/2001/XMLSchema#dateTime"}],
+                    "http://schema.org/rangeIncludes": [{"@id": "http://www.w3.org/2001/XMLSchema#date"}],
                     "http://www.w3.org/2000/01/rdf-schema#comment":
                     [{"@language": "en", "@value": "The date on which this resource was most recently modified in some way."}],
                     "http://www.w3.org/2000/01/rdf-schema#label": [{"@language": "en", "@value": "Date Modified"}],
@@ -1558,7 +1558,7 @@ export default {
                     "@type": ["http://www.w3.org/2000/01/rdf-schema#Property"],
                     "http://schema.org/domainIncludes":
                     [{"@id": "https://schema.cassproject.org/0.4/ConceptScheme"}],
-                    "http://schema.org/rangeIncludes": [{"@id": "http://www.w3.org/2001/XMLSchema#dateTime"}],
+                    "http://schema.org/rangeIncludes": [{"@id": "http://www.w3.org/2001/XMLSchema#date"}],
                     "http://www.w3.org/2000/01/rdf-schema#comment":
                     [{"@language": "en", "@value": "The date on which this resource was most recently modified in some way."}],
                     "http://www.w3.org/2000/01/rdf-schema#label": [{"@language": "en", "@value": "Date Modified"}],
@@ -2266,7 +2266,7 @@ export default {
                     "@type": ["http://www.w3.org/2000/01/rdf-schema#Property"],
                     "http://schema.org/domainIncludes":
                     [{"@id": "https://schema.cassproject.org/0.4/ConceptScheme"}],
-                    "http://schema.org/rangeIncludes": [{"@id": "http://www.w3.org/2001/XMLSchema#dateTime"}],
+                    "http://schema.org/rangeIncludes": [{"@id": "http://www.w3.org/2001/XMLSchema#date"}],
                     "http://www.w3.org/2000/01/rdf-schema#comment":
                     [{"@language": "en", "@value": "The date on which this resource was most recently modified in some way."}],
                     "http://www.w3.org/2000/01/rdf-schema#label": [{"@language": "en", "@value": "Date Modified"}],


### PR DESCRIPTION
Type for dateModified should be date, not dateTime, based on conversation in the following issue:
https://github.com/cassproject/cass-editor/issues/666

Fix includes check for existing dateTime value in dateModified and converts to date when a change is made to the value. 
