### PR TITLE
Compute precedes and precededBy on import of ProgressionModel

### DIFF
--- a/src/store/modules/editor.js
+++ b/src/store/modules/editor.js
@@ -62,6 +62,7 @@ const state = {
     lastEditToUndo: null,
     recomputeHierarchy: false,
     recomputePrecedence: false,
+    recomputePrecedenceAfterReorder: false,
     selectedCompetenciesAsProperties: null,
     refreshLevels: false,
     refreshAlignments: false,
@@ -183,6 +184,9 @@ const mutations = {
     },
     recomputePrecedence(state, boolean) {
         state.recomputePrecedence = boolean;
+    },
+    recomputePrecedenceAfterReorder(state, boolean) {
+        state.recomputePrecedenceAfterReorder = boolean;
     },
     selectedCompetenciesAsProperties(state, comps) {
         state.selectedCompetenciesAsProperties = comps;
@@ -515,6 +519,9 @@ const getters = {
     },
     recomputePrecedence: function(state) {
         return state.recomputePrecedence;
+    },
+    recomputePrecedenceAfterReorder: function(state) {
+        return state.recomputePrecedenceAfterReorder;
     },
     selectedCompetenciesAsProperties: function(state) {
         return state.selectedCompetenciesAsProperties;

--- a/src/views/progressionModel/ProgressionHierarchy.vue
+++ b/src/views/progressionModel/ProgressionHierarchy.vue
@@ -346,6 +346,9 @@ export default {
         },
         recomputePrecedence: function() {
             return this.$store.getters['editor/recomputePrecedence'];
+        },
+        recomputePrecedenceAfterReorder: function() {
+            return this.$store.getters['editor/recomputePrecedenceAfterReorder'];
         }
     },
     watch: {
@@ -493,6 +496,13 @@ export default {
             }
             let restructureSuccess = false;
             let originalStructure = structure.map(i => ({...i}));
+
+            if (this.recomputePrecedenceAfterReorder) {
+                this.$store.commit('editor/recomputePrecedenceAfterReorder', false);
+                this.$store.commit('editor/recomputePrecedence', true);
+                await this.reorder(structure, "ceterms:precedes");
+                await this.reorder(structure, "ceterms:precededBy");
+            }
             if (this.recomputePrecedence) {
                 this.$store.commit('editor/recomputePrecedence', false);
                 restructureSuccess = await this.setPrecedes(structure);
@@ -1364,6 +1374,7 @@ export default {
         openFramework: async function() {
             var f = await EcConceptScheme.get(this.container.shortId());
             this.$store.commit('editor/framework', f);
+            this.$store.commit('editor/recomputePrecedenceAfterReorder', true);
             this.$router.push({name: "progressionModel", params: {frameworkId: this.container.id}});
         },
         onClickCreateNew: async function() {


### PR DESCRIPTION
When importing Progression Model, compute precedence based on properties in import and then set remaining precedes and precededBy properties as needed.