### PR TITLE
Remove property by value instead of index.

### DIFF
--- a/src/lode/components/Property.vue
+++ b/src/lode/components/Property.vue
@@ -196,6 +196,7 @@ TO DO MAYBE: Separate out property by editing or not.
                         v-if="editingProperty && limitedConcepts.length > 0">
                         <PropertyString
                             :index="index"
+                            :propertyValue="expandedThing[expandedProperty][index]"
                             :expandedProperty="expandedProperty"
                             :expandedThing="expandedThing"
                             :expandedValue="expandedValue"
@@ -204,6 +205,7 @@ TO DO MAYBE: Separate out property by editing or not.
                             :view="view"
                             :options="limitedConcepts"
                             :profile="profile"
+                            @removeByValue="removeByValue($event)"
                             @remove="remove(item)" />
                     </div>
                     <div
@@ -296,6 +298,7 @@ TO DO MAYBE: Separate out property by editing or not.
                     v-else-if="editingProperty && !checkedOptions && !(limitedConcepts.length > 0) && !(limitedTypes.length > 0)">
                     <PropertyString
                         :index="index"
+                        :propertyValue="expandedThing[expandedProperty][index]"
                         :expandedProperty="expandedProperty"
                         :expandedThing="expandedThing"
                         :expandedValue="expandedValue"
@@ -305,6 +308,7 @@ TO DO MAYBE: Separate out property by editing or not.
                         :addSingle="isNotDeletable()"
                         :options="(profile && profile[expandedProperty] && profile[expandedProperty]['options']) ? profile[expandedProperty]['options'] : null"
                         :profile="profile"
+                        @removeByValue="removeByValue($event)"
                         @remove="remove(item)" />
                 </div>
                 <!-- text view has language -->
@@ -968,6 +972,9 @@ export default {
                 rld.type = type.split("/").pop();
                 this.$parent.add(this.expandedProperty, rld);
             }
+        },
+        removeByValue: async function(value) {
+            this.$parent.removeByValue(this.expandedProperty, value);
         },
         remove: async function(index) {
             if (this.profile && this.profile[this.expandedProperty] && this.profile[this.expandedProperty]["remove"]) {

--- a/src/lode/components/PropertyString.vue
+++ b/src/lode/components/PropertyString.vue
@@ -242,6 +242,10 @@ export default {
         profile: Object,
         // True if adding a single property
         addSingle: Boolean,
+        propertyValue: {
+            type: Object,
+            default: function() { return undefined; }
+        },
         valueFromSearching: null,
         view: {
             type: String,
@@ -262,7 +266,7 @@ export default {
         }
         if (EcArray.isArray(property)) {
             return {
-                text: this.expandedThing[this.expandedProperty][this.index],
+                text: this.propertyValue ? this.propertyValue : this.expandedThing[this.expandedProperty][this.index],
                 indexInternal: this.index,
                 isOpen: false,
                 search: "",
@@ -318,7 +322,7 @@ export default {
         if (this.profile && this.profile[this.expandedProperty] && this.profile[this.expandedProperty]["resource"]) {
             this.isResource = true;
             if (this.expandedValue) {
-                this.text = this.expandedValue[this.index];
+                this.text = this.propertyValue ? this.propertyValue : this.expandedValue[this.index];
             } else {
                 this.text = {};
             }
@@ -490,7 +494,11 @@ export default {
             }
         },
         clickConfirmRemove: function() {
-            this.$emit('remove');
+            if (this.propertyValue) {
+                this.$emit('removeByValue', this.propertyValue);
+            } else {
+                this.$emit('remove');
+            }
             this.removePropertyConfirmModal = false;
         },
         closeModal: function() {

--- a/src/store/modules/editor.js
+++ b/src/store/modules/editor.js
@@ -66,6 +66,7 @@ const state = {
     selectedCompetenciesAsProperties: null,
     refreshLevels: false,
     refreshAlignments: false,
+    refreshProperties: false,
     conceptMode: false,
     collectionMode: false,
     progressionMode: false,
@@ -196,6 +197,9 @@ const mutations = {
     },
     refreshAlignments(state, boolean) {
         state.refreshAlignments = boolean;
+    },
+    refreshProperties(state, boolean) {
+        state.refreshProperties = boolean;
     },
     conceptMode(state, boolean) {
         if (boolean) {
@@ -531,6 +535,9 @@ const getters = {
     },
     refreshAlignments: function(state) {
         return state.refreshAlignments;
+    },
+    refreshProperties: function(state) {
+        return state.refreshProperties;
     },
     conceptMode: function(state) {
         return state.conceptMode;


### PR DESCRIPTION
Remove property by value to control exactly which property should be removed. Removing by index was referencing incorrect properties in some situations.
If multiple properties with the same value exist on a competency or framework then the first of the properties with said value will be removed when requested. 