### PR TITLE
Do not implicitly reorder progression when displaying hierarchy.

### DIFF
--- a/src/views/progressionModel/ProgressionHierarchy.vue
+++ b/src/views/progressionModel/ProgressionHierarchy.vue
@@ -345,10 +345,10 @@ export default {
             if (this.container["skos:hasTopConcept"] != null) { precache = precache.concat(this.container["skos:hasTopConcept"]); }
             if (precache.length > 0) {
                 this.repo.multiget(precache, function(success) {
-                    me.computeHierarchy(true);
+                    me.computeHierarchy(false);
                 }, appError);
             } else {
-                me.computeHierarchy(true);
+                me.computeHierarchy(false);
             }
             return this.structure;
         },


### PR DESCRIPTION
For Progression Models, only reorder the hierarchy if user selects option to do so. This prevents reordering when a user has moved, added, or deleted a level before updating precedence.  