### PR TITLE
Fix ownedByMe query param

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -107,7 +107,7 @@ export default {
                 if (this.queryParams.user === "wait") {
                     this.$store.commit('featuresEnabled/shareEnabled', false);
                 }
-                if (this.queryParams.ownedByNe === "true") {
+                if (this.queryParams.ownedByMe === "true") {
                     this.$store.commit('featuresEnabled/ownedByMe', true);
                 }
             }


### PR DESCRIPTION
Fixed spelling of ownedByMe query parameter. This param defaults search of objects to those owned by the user. 