### PR TITLE
Ce 1135a

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ The cass-editor can be populated with templates that set initial properties of n
     );
   
 ## Only show frameworks that individual owns.
-Along with user credentials, the cass-editor can be configured to not show others' frameworks. This functionality can be enabled by the URL parameter `show=mine`.
+Along with user credentials, the cass-editor can be configured to not show others' frameworks. This functionality can be enabled by the URL parameters `show=mine` or `ownedByMe=true`.
 
 ## Only show concept schemes that individual owns.
 When linking a concept to a competency, the cass-editor can be configured to not show others' concept schemes. This functionality can be enabled by the URL parameter `conceptShow=mine`.

--- a/src/App.vue
+++ b/src/App.vue
@@ -107,7 +107,9 @@ export default {
                 if (this.queryParams.user === "wait") {
                     this.$store.commit('featuresEnabled/shareEnabled', false);
                 }
-                if (this.queryParams.ownedByMe === "true") {
+                // Add support for show=mine. This param was already being used by CE, but was no longer functioning as expected.
+                //  OwnedByMe offers the expected functionality. Including show=mine for compatibility with existing clients.
+                if (this.queryParams.ownedByMe === "true" || this.queryParams.show === "mine") {
                     this.$store.commit('featuresEnabled/ownedByMe', true);
                 }
             }

--- a/src/components/framework/RightAside.vue
+++ b/src/components/framework/RightAside.vue
@@ -33,7 +33,8 @@
         <slot name="right-aside-content">
             <Component
                 @editResourceDetails="$emit('editResource', $event)"
-                :is="rightAsideContent" />
+                :is="rightAsideContent"
+                v-bind="properties" />
         </slot>
     </aside>
 </template>
@@ -67,6 +68,15 @@ export default {
         },
         rightAsideContent: function() {
             return this.$store.getters['app/rightAsideContent'];
+        },
+        properties: function() {
+            if (this.rightAsideContent === 'FilterAndSort') {
+                return {
+                    ownedByMe: this.$store.state.featuresEnabled.ownedByMe
+                };
+            } else {
+                return {};
+            }
         }
     }
 };

--- a/src/components/framework/Search.vue
+++ b/src/components/framework/Search.vue
@@ -12,6 +12,7 @@ placed anywhere in a structured html element such as a <section> or a <div>
             v-if="!selectedFramework">
             <SearchBar
                 filterSet="basic"
+                :ownedByMe="ownedByMe"
                 :allowShowFrameworks="allowShowFrameworks"
                 :searchType="searchType" />
         </div>
@@ -197,6 +198,9 @@ export default {
                 }
             }
             return search;
+        },
+        ownedByMe: function() {
+            return this.$store.getters["featuresEnabled.ownedByMe"];
         },
         paramObj: function() {
             let obj = {};

--- a/src/components/framework/SearchBar.vue
+++ b/src/components/framework/SearchBar.vue
@@ -128,7 +128,7 @@ export default {
     props: {
         ownedByMe: {
             type: Boolean,
-            default: false
+            default: true
         },
         view: {
             type: String,
@@ -155,7 +155,7 @@ export default {
         return {
             searchTerm: '',
             basicSort: '',
-            basicFilter: ''
+            basicFilter: this.ownedByMe
         };
     },
     watch: {
@@ -170,26 +170,11 @@ export default {
             this.$store.commit("app/sortResults", {id: val});
         },
         basicFilter: function(val) {
-            appLog(val);
-            var filter;
-            if (val === true) {
-                filter = {
-                    id: 'ownedByMe',
-                    checked: true
-                };
-            } else {
-                filter = {
-                    id: 'ownedByMe',
-                    checked: false
-                };
-            }
-            this.$store.commit("app/quickFilters", [filter]);
+            this.setFilters(val);
         }
     },
     mounted: function() {
-        if (this.ownedByMe) {
-            this.basicFilter = true;
-        }
+        this.setFilters(this.ownedByMe);
         let searchTerm = this.$store.getters['app/searchTerm'];
         if (searchTerm && searchTerm.length > 0) {
             this.searchTerm = searchTerm;
@@ -212,6 +197,21 @@ export default {
             let objIndex = filterArray.findIndex(obj => obj.id === val.id);
             filterArray[objIndex].checked = false;
             this.$store.commit(storeCaller, filterArray);
+        },
+        setFilters(val) {
+            var filter;
+            if (val === true) {
+                filter = {
+                    id: 'ownedByMe',
+                    checked: true
+                };
+            } else {
+                filter = {
+                    id: 'ownedByMe',
+                    checked: false
+                };
+            }
+            this.$store.commit("app/quickFilters", [filter]);
         },
         updateSearchTerm: function(e) {
             this.$store.commit('app/searchTerm', e);

--- a/src/components/frameworks/FilterAndSort.vue
+++ b/src/components/frameworks/FilterAndSort.vue
@@ -87,6 +87,12 @@ import {cassUtil} from '@/mixins/cassUtil.js';
 
 export default {
     name: 'FilterAndSort',
+    props: {
+        ownedByMe: {
+            type: Boolean,
+            default: false
+        }
+    },
     data() {
         return {
             sortResults: [
@@ -115,7 +121,7 @@ export default {
                 },
                 {
                     id: 'ownedByMe',
-                    checked: false,
+                    checked: this.ownedByMe,
                     label: 'Owned by me',
                     enabled: true
                 },

--- a/src/views/directory/Directory.vue
+++ b/src/views/directory/Directory.vue
@@ -144,6 +144,7 @@
                     <div class="column">
                         <SearchBar
                             filterSet="all"
+                            :ownedByMe="ownedByMe"
                             searchType="framework" />
                     </div>
                     <div class="column is-1" />
@@ -377,6 +378,9 @@ export default {
                 search += "\")";
             }
             return search;
+        },
+        ownedByMe: function() {
+            return this.$store.getters["featuresEnabled.ownedByMe"];
         },
         paramObj: function() {
             let obj = {};


### PR DESCRIPTION
https://github.com/cassproject/cass-editor/issues/1135
The url parameter "ownedByMe=true" and "show=mine" now both achieve the same functionality. Setting either of these parameters will default to showing frameworks and competencies owned by the currently logged in user. Unchecking the "Owned By Me" option in the filter options will allow the user to view all frameworks or competencies.  