### PR TITLE
Click to select self and double-click to select self plus child nodes

### DIFF
--- a/src/lode/components/Hierarchy.vue
+++ b/src/lode/components/Hierarchy.vue
@@ -362,6 +362,7 @@
                     :properties="properties"
                     :expandAll="expanded==true"
                     :parentChecked="false"
+                    :propagateParentCheck="false"
                     :shiftKey="shiftKey"
                     :arrowKey="arrowKey"
                     :largeNumberOfItems="hasLargeNumberOfItems"

--- a/src/lode/components/Property.vue
+++ b/src/lode/components/Property.vue
@@ -318,11 +318,14 @@ TO DO MAYBE: Separate out property by editing or not.
                     <span
                         class="tag is-size-7 is-light"
                         v-if="expandedProperty !== 'http://schema.org/name' && expandedProperty !== 'dcterms:title' && expandedProperty !== 'skos:prefLabel'">{{ displayLabel }}</span>
-                    <span class="language">
+                    <span
+                        @click="setCheckbox($event)"
+                        class="language">
                         {{ expandedValue[index]["@language"] + ": " }}
                     </span>
                     <span
                         :title="expandedValue[index]['@value']"
+                        @click="setCheckbox($event)"
                         class="value">
                         {{ expandedValue[index]["@value"] }}
                     </span>
@@ -714,6 +717,10 @@ export default {
         }
     },
     methods: {
+        setCheckbox(event) {
+            event.preventDefault();
+            this.$emit('set-checkbox');
+        },
         async addConceptInner(conceptUri) {
             EcConcept.get(conceptUri).then((concept) => {
                 this.limitedConcepts.push({

--- a/src/lode/components/Thing.vue
+++ b/src/lode/components/Thing.vue
@@ -116,6 +116,7 @@
                                 :editingThing="editingThing"
                                 :canEdit="false"
                                 :profile="profile"
+                                @set-checkbox="$emit('set-checkbox')"
                                 @select="select" />
                             <slot name="frameworkTags" />
                         </template>
@@ -132,6 +133,7 @@
                                 :editingThing="editingThing"
                                 :canEdit="allowPropertyEdits(key)"
                                 :profile="profile"
+                                @set-checkbox="$emit('set-checkbox')"
                                 @select="select" />
                         </template>
                         <template v-else-if="showViewProperties && viewProperties[heading]">
@@ -146,6 +148,7 @@
                                 :editingThing="editingThing"
                                 :canEdit="allowPropertyEdits(key)"
                                 :profile="profile"
+                                @set-checkbox="$emit('set-checkbox')"
                                 @select="select" />
                         </template>
                     </div>


### PR DESCRIPTION
Selecting competencies within frameworks allows for moving or editing them. If multiple are selected, then moving is not possible. For this reason, functionality has been added to select a single competency (the parent) with a single-click or select the parent and all children with a double-click. 