### PR TITLE
Highlight children to be moved

### DIFF
--- a/src/lode/components/Hierarchy.vue
+++ b/src/lode/components/Hierarchy.vue
@@ -361,8 +361,6 @@
                     @draggable-check="onDraggableCheck"
                     :properties="properties"
                     :expandAll="expanded==true"
-                    :parentChecked="false"
-                    :propagateParentCheck="false"
                     :shiftKey="shiftKey"
                     :arrowKey="arrowKey"
                     :largeNumberOfItems="hasLargeNumberOfItems"

--- a/src/lode/components/HierarchyNode.vue
+++ b/src/lode/components/HierarchyNode.vue
@@ -16,6 +16,7 @@
                 {'show-all': filter === 'showAll'},
                 { 'is-focused': isItemFocused},
                 { 'is-selected': checked},
+                { 'is-highlighted': highlighted},
                 { 'is-copied': isItemCopied},
                 { 'is-cut': isItemCut},
                 { 'can-paste': canPaste},
@@ -342,6 +343,7 @@
                     @remove-object="removeObject"
                     :properties="properties"
                     :parentChecked="checked"
+                    :parentHighlighted="parentHighlighted ? parentHighlighted : checked"
                     :propagateParentChecked="propagateChecked === 'parent' ? propagateParentChecked : propagateChecked"
                     :shiftKey="shiftKey"
                     :arrowKey="arrowKey"
@@ -382,6 +384,7 @@ export default {
         properties: String,
         expandAll: Boolean,
         parentChecked: Boolean,
+        parentHighlighted: Boolean,
         propagateParentChecked: String,
         view: {
             type: String,
@@ -577,6 +580,13 @@ export default {
                 return this.canEditAny(this.obj);
             }
             return true;
+        },
+        highlighted: function() {
+            if (this.parentHighlighted) {
+                return true;
+            } else {
+                return this.checked;
+            }
         }
     },
     // used to help the parent know when nodes stop rendering

--- a/src/scss/framework.scss
+++ b/src/scss/framework.scss
@@ -398,6 +398,10 @@ drag, drag, and chosen states
                 background-color: rgba($link, .2);
                 border-radius: 0rem;
             }
+            .lode__hierarchy-item.is-highlighted {
+                background-color: rgba($link, .2);
+                border-radius: 0rem;
+            }
             .lode__hierarchy-item.is-cut {
                 border-radius: 0rem;
                 border: dashed 2px $dark;

--- a/src/views/conceptScheme/ConceptHierarchy.vue
+++ b/src/views/conceptScheme/ConceptHierarchy.vue
@@ -237,6 +237,7 @@
                     :properties="properties"
                     :expandAll="expanded==true"
                     :parentChecked="false"
+                    :parentHighlighted="false"
                     :shiftKey="shiftKey"
                     :arrowKey="arrowKey"
                     :largeNumberOfItems="hasLargeNumberOfItems" />

--- a/src/views/progressionModel/ProgressionHierarchy.vue
+++ b/src/views/progressionModel/ProgressionHierarchy.vue
@@ -244,6 +244,7 @@
                     :properties="properties"
                     :expandAll="expanded==true"
                     :parentChecked="false"
+                    :parentHighlighted="false"
                     :shiftKey="shiftKey"
                     :arrowKey="arrowKey" />
             </draggable>


### PR DESCRIPTION
Highlight (without selecting) the child competency nodes that will be moved along with a parent node.