### PR TITLE
Add double click, single click options to concepts and progressions.

### DIFF
--- a/src/lode/components/HierarchyNode.vue
+++ b/src/lode/components/HierarchyNode.vue
@@ -623,13 +623,13 @@ export default {
     },
     methods: {
         setCheckbox: function() {
-            if (this.view === 'framework') {
+            if (this.view === 'framework' || this.view === 'concept') {
                 this.checked = !this.checked;
                 this.propagateChecked = 'false';
             }
         },
         checkForDblClick: function() {
-            if (this.view === 'framework') {
+            if (this.view === 'framework' || this.view === 'concept') {
                 // Select all children on double click. PropagateChecked exists on each node and can be set to true, false, or parent.
                 // It is set to parent by default, indicating that the node should take on the value of the parentPropagateChecked.
                 // If this node's checkbox is changed, then propagateChecked takes on the value of false to select only itself and
@@ -989,7 +989,7 @@ export default {
         },
         parentChecked: function() {
             if (!this.newCompetency) {
-                if (this.view === 'framework') {
+                if (this.view === 'framework' || this.view === 'concept') {
                     if (this.propagateParentChecked === 'true') {
                         this.checked = this.parentChecked;
                     }

--- a/src/views/conceptScheme/ConceptHierarchy.vue
+++ b/src/views/conceptScheme/ConceptHierarchy.vue
@@ -236,8 +236,7 @@
                     @draggable-check="onDraggableCheck"
                     :properties="properties"
                     :expandAll="expanded==true"
-                    :parentChecked="false"
-                    :parentHighlighted="false"
+                    :propagateParentChecked="parent"
                     :shiftKey="shiftKey"
                     :arrowKey="arrowKey"
                     :largeNumberOfItems="hasLargeNumberOfItems" />

--- a/src/views/progressionModel/ProgressionHierarchy.vue
+++ b/src/views/progressionModel/ProgressionHierarchy.vue
@@ -243,8 +243,7 @@
                     @draggable-check="onDraggableCheck"
                     :properties="properties"
                     :expandAll="expanded==true"
-                    :parentChecked="false"
-                    :parentHighlighted="false"
+                    :propagateParentChecked="parent"
                     :shiftKey="shiftKey"
                     :arrowKey="arrowKey" />
             </draggable>


### PR DESCRIPTION
Single click selects parent concept/taxon and double-click selects parent and all child concepts/taxons.