### PR TITLE
Fix link from collections.

### DIFF
--- a/src/components/framework/ListItemInfo.vue
+++ b/src/components/framework/ListItemInfo.vue
@@ -1597,7 +1597,7 @@ export default {
         },
         shareLink: function() {
             let link = window.location.href;
-            link = link.replace('/frameworks', '').replace('/directory', '').replace('#', '');
+            link = link.replace('/frameworks', '').replace('/directory', '');
             if (this.objectType === "Directory") {
                 if (link.contains('?')) {
                     return (link + "&directoryId=" + this.objectShortId);


### PR DESCRIPTION
Addresses invalid link when attempting to copy a link to a collection.
 https://github.com/cassproject/cass-editor/issues/1250