### PR TITLE
Display org name in login button if logged in as org.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -777,7 +777,7 @@ export default {
                     if (data.action === "identity") {
                         identity = new EcIdentity();
                         identity.ppk = EcPpk.fromPem(data.identity);
-                        identity.displayName = "You";
+                        identity.displayName = data.name ? data.name : "You";
                         EcIdentityManager.default.addIdentity(identity);
                         callback();
                         var message = {

--- a/src/components/SideNav.vue
+++ b/src/components/SideNav.vue
@@ -25,7 +25,7 @@
                     @click="showUserInfo = !showUserInfo">
                     <span
                         :title="'Signed in as: ' + displayName">
-                        {{ loggedOnPerson.email != null ? loggedOnPerson.email.slice(0, 2) : "ME" }}
+                        {{ loggedOnPerson.email != null ? loggedOnPerson.email.slice(0, 2) : (displayName !== 'No user' ? displayName.slice(0, 2) : "ME") }}
                     </span>
                 </button>
             </div>
@@ -650,6 +650,8 @@ export default {
         displayName: function() {
             if (this.isLoggedOn) {
                 return this.loggedOnPerson.name;
+            } else if (this.availableIdentities.length > 0) {
+                return this.availableIdentities[0].displayName ? this.availableIdentities[0].displayName : 'Organization';
             } else {
                 return 'No user';
             }


### PR DESCRIPTION
Previous update to login only displays initials if user is logged in as a Person. 
Added support for users logged in as organizations. If the identity contains a displayName, the initials of the displayName will be shown on the login button.  