### PR TITLE
Fix Vue prop warning for propagateParentChecked

### DIFF
--- a/src/lode/components/HierarchyNode.vue
+++ b/src/lode/components/HierarchyNode.vue
@@ -344,7 +344,7 @@
                     :properties="properties"
                     :parentChecked="checked"
                     :parentHighlighted="parentHighlighted ? parentHighlighted : checked"
-                    :propagateParentChecked="propagateChecked === 'parent' ? propagateParentChecked : propagateChecked"
+                    :propagateParentChecked="propagateChecked === 'parent' ? propagateParentChecked : (propagateChecked === 'true' ? 'true' : 'false')"
                     :shiftKey="shiftKey"
                     :arrowKey="arrowKey"
                     :largeNumberOfItems="largeNumberOfItems"
@@ -385,7 +385,9 @@ export default {
         expandAll: Boolean,
         parentChecked: Boolean,
         parentHighlighted: Boolean,
-        propagateParentChecked: String,
+        propagateParentChecked: {
+            type: String
+        },
         view: {
             type: String,
             default: 'framework'


### PR DESCRIPTION
Minor fix to remove a warning in client console. 