### PR TITLE
Allow multiple values for altCodedNotation

### DIFF
--- a/src/mixins/ctdlasnProfile.js
+++ b/src/mixins/ctdlasnProfile.js
@@ -877,7 +877,6 @@ export default {
                     "http://www.w3.org/2000/01/rdf-schema#comment":
                     [{"@language": "en", "@value": "An alphanumeric notation or ID code identifying this competency in common use among end-users."}],
                     "http://www.w3.org/2000/01/rdf-schema#label": [{"@language": "en", "@value": "Alternative Coded Notation"}],
-                    "max": 1,
                     "heading": "Context"
                 },
                 "https://purl.org/ctdlasn/terms/comprisedOf": {


### PR DESCRIPTION
Per conversation with CE on 7/12/23: AltCodedNotation should be updated to handle multiple values to support the use case of multiple coded notations. The single codedNotation property cannot currently be changed, so the alternative solution is to use altCodedNotation for additional values. 