### PR TITLE
Enabling User Management for the Platform One JWT Auth

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -139,7 +139,7 @@ export default {
             }, appError, async(loginInfo) => {
                 r.fetchServerAdminKeys(() => {}, appError);
                 this.$store.commit('user/repositorySsoOptions', loginInfo);
-                if (loginInfo.ssoPublicKey != null && loginInfo.ssoLogin == null) {
+                if (loginInfo.ssoPublicKey != null && loginInfo.ssoLogin == null && loginInfo.ssoViaP1 == null) {
                     this.$store.commit('featuresEnabled/loginEnabled', false);
                     this.$store.commit('featuresEnabled/userManagementEnabled', false);
                 }


### PR DESCRIPTION
Adds an additional condition before disabling user management features for users with public keys on the P1 JWT-based deployments.