### PR TITLE
Remove slash from end of url

### DIFF
--- a/src/lode/components/ThingEditing.vue
+++ b/src/lode/components/ThingEditing.vue
@@ -842,7 +842,9 @@ export default {
         saveNewProperty: async function() {
             // Validate input
             var property = this.addingProperty;
+            // Remove unnecessary slash from end of url. github #827
             var value = (this.addingValues.length > 0) ? this.addingValues[0] : undefined;
+            value = value.endsWith("/") ? value.slice(0, value.length - 1) : value;
             var range = this.addingRange;
             this.errorMessage = [];
             this.errorMessage = [];


### PR DESCRIPTION
Relation url ending in a slash causes visual issue in Property details. Fix cleans up the unnecessary url before save.