### PR TITLE
Wider Comparison for the isAdmin() Check

### DIFF
--- a/src/mixins/cassUtil.js
+++ b/src/mixins/cassUtil.js
@@ -102,8 +102,17 @@ export const cassUtil = {
             return item.canEditAny(EcIdentityManager.default.getMyPks());
         },
         isAdmin: function() {
-            if (EcIdentityManager.default.ids.length > 0 && window.repo.adminKeys != null && window.repo.adminKeys.length > 0) {
-                if (window.repo.adminKeys[0] === EcIdentityManager.default.ids[0].ppk.toPk().toPem()) { return true; }
+            let adminKeys = window.repo.adminKeys;
+            let userIds = EcIdentityManager.default.ids;
+            if (!Array.isArray(adminKeys)) return false;
+            if (!Array.isArray(userIds)) return false;
+            for (let userId of userIds) {
+                let userKey = userId.ppk.toPk().toPem();
+                for (let adminKey of adminKeys) {
+                    if (userKey === adminKey) {
+                        return true;
+                    }
+                }
             }
             return false;
         },

--- a/src/mixins/common.js
+++ b/src/mixins/common.js
@@ -56,8 +56,17 @@ export default {
             return item.canEditAny(EcIdentityManager.default.getMyPks());
         },
         isAdmin: function() {
-            if (EcIdentityManager.default.ids.length > 0 && window.repo.adminKeys != null && window.repo.adminKeys.length > 0) {
-                if (window.repo.adminKeys[0] === EcIdentityManager.default.ids[0].ppk.toPk().toPem()) { return true; }
+            let adminKeys = window.repo.adminKeys;
+            let userIds = EcIdentityManager.default.ids;
+            if (!Array.isArray(adminKeys)) return false;
+            if (!Array.isArray(userIds)) return false;
+            for (let userId of userIds) {
+                let userKey = userId.ppk.toPk().toPem();
+                for (let adminKey of adminKeys) {
+                    if (userKey === adminKey) {
+                        return true;
+                    }
+                }
             }
             return false;
         },


### PR DESCRIPTION
Updating the two `isAdmin()` functions to compare all public keys for the current user against all admin public keys provided by the ping.

The original check just looked at the first key in both, and the updated ping response will also include known users who have logged in as admins since the server process started.

This is a sister PR for https://github.com/cassproject/CASS/pull/320